### PR TITLE
Auth0 display and route layout

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7015,7 +7015,6 @@
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"

--- a/client/package.json
+++ b/client/package.json
@@ -31,5 +31,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "proxy": "http://localhost:5000"
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,9 +4,12 @@ import { PrivateRoute } from "./components/PrivateRoute";
 import { Login } from "./components/Login";
 import { About } from "./components/About";
 import { noMatch } from "./components/noMatch/";
-import { CheeseDetail } from "./pages/CheeseDetail";
 import { Profile } from "./components/Profile";
+import { Survey } from "./pages/Survey/Survey.component";
+import { Plants } from "./pages/Plants/Plants.component";
+import { PlantDetail } from "./pages/PlantDetail/PlantDetail.component";
 // import { NavBar } from "./components/NavBar";
+import { PagePlaceholder } from './pages/PagePlaceholder/PagePlaceholder.component';
 
 function App() {
   return (
@@ -19,8 +22,10 @@ function App() {
           <About />
           <Login />  
         </Route>
-        <Route exact path="/cheese/:id" component={CheeseDetail} />
-        <PrivateRoute path="/profile" component={Profile} />
+        <PrivateRoute exact path="/dashboard" component={Profile} />
+        <PrivateRoute exact path="/survey" component={Survey} />
+        <PrivateRoute exact path="/plants" component={Plants} />
+        <PrivateRoute exact path="/plants/:id" component={PlantDetail} />
         <Route component={noMatch} />
       </Switch>
     </Router>

--- a/client/src/components/Login/Login.component.js
+++ b/client/src/components/Login/Login.component.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button } from 'reactstrap';
 import { useAuth0 } from "../../react-auth0-spa";
-import { Link } from "react-router-dom";
+import { Redirect } from "react-router-dom";
 
 export const Login = (props) => {
   const { isAuthenticated, loginWithRedirect, logout } = useAuth0();
@@ -18,12 +18,7 @@ export const Login = (props) => {
         </Button>
       )}
       
-      {isAuthenticated && (
-        <span className="text-center">
-            <Button color="warning" onClick={() => logout()}>Log out</Button>
-            <Link to="/profile"><Button>View Profile</Button></Link>
-        </span>
-        )}
+      {isAuthenticated && (<Redirect to="/dashboard" />)}
     </div>
   );
 };

--- a/client/src/components/Profile/Profile.component.js
+++ b/client/src/components/Profile/Profile.component.js
@@ -4,7 +4,7 @@ import { useAuth0 } from "../../react-auth0-spa";
 import { Link } from "react-router-dom";
 
 export const Profile = (props) => {
-  const { logout, loading, user } = useAuth0();
+  const { logout, loading, user} = useAuth0();
 
   if (loading || !user) {
     return (
@@ -28,7 +28,7 @@ export const Profile = (props) => {
       
       <h2>JSON below of your information!</h2>
       <br></br>
-      <code>{JSON.stringify(user, null, 2)}</code>
+      <code>{JSON.stringify(user, null, 2,)}</code>
       </div>
   );
 };

--- a/client/src/pages/CheeseDetail/index.js
+++ b/client/src/pages/CheeseDetail/index.js
@@ -28,7 +28,7 @@ export class CheeseDetail extends React.Component {
                     console.log(`ERR - Could not load cheese id: ${id}`, err),
                     this.setState({
                         cheese: {
-                            name: 'Smelly Cheese',
+                            name: 'Smellyyyy Cheese',
                             price: 1000,
                             description: 'Stinky stuffffff!!',
                         }

--- a/client/src/pages/PagePlaceholder/PagePlaceholder.component.js
+++ b/client/src/pages/PagePlaceholder/PagePlaceholder.component.js
@@ -1,0 +1,29 @@
+import React, { Fragment } from 'react';
+
+export const PagePlaceholder = (props) => {
+    const { params } = props.match;
+    return (
+        <div>
+            <h1>Welcome to the {props.match.url} Page</h1>
+            <p>
+            <table>
+                    <thead>
+                        <th>Key</th>
+                        <th>Value</th>
+                    </thead>
+                    <tbody>
+                        {Object.keys(params).map( key => {
+                
+                    return (
+                        <Fragment>
+                            <td>{key}</td>
+                            <td>{params[key]}</td>
+                        </Fragment>
+                    );
+            })}
+                    </tbody>            
+                </table>
+            </p>
+        </div>
+    );
+}

--- a/client/src/pages/PlantDetail/PlantDetail.component.js
+++ b/client/src/pages/PlantDetail/PlantDetail.component.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+
+export class PlantDetail extends Component {
+    constructor(props){
+        super(props);
+    }
+    
+    componentDidMount(){
+        console.log('Plant Id', this.props.match.params.id);
+    }
+    
+    render() {
+        return (
+            <div>
+                <h1>Plant ID: {this.props.match.params.id}</h1>
+            </div>
+        );
+    }
+}

--- a/client/src/pages/Plants/Plants.component.js
+++ b/client/src/pages/Plants/Plants.component.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+
+export class Plants extends Component {
+    constructor(props){
+        super(props);
+    }
+    
+    componentDidMount(){
+        console.log('Plant Id', this.props.match.params.id);
+    }
+    
+    render() {
+        return (
+            <div>
+                <h1>Plants Page</h1>
+            </div>
+        );
+    }
+}

--- a/client/src/pages/Survey/Survey.component.js
+++ b/client/src/pages/Survey/Survey.component.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+
+export class Survey extends Component {
+    constructor(props){
+        super(props);
+    }
+    
+    componentDidMount(){
+
+    }
+    
+    render() {
+        return (
+            <div>
+                <h1>Survey page</h1>
+            </div>
+        );
+    }
+}

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -1,5 +1,6 @@
 import axios from 'axios'
 
+
 export default class API {
     static getCheeseById(cheeseId) {
         return axios.get(`localhost:5000/api/cheese/${cheeseId}`);

--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
     "morgan": "~1.9.1",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2"
-  }
+  },
+  "proxy": "http://localhost:5000"
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -12,9 +12,12 @@ router.get('/api/health', function(req, res, next) {
 router.get('/api/cheese/:id', (req, res) => {
   console.log('requested cheese id:', req.params.id);
   res.json({
+    cheese: {
+    id: 1,
     name: "Humboldt Fog",
     price: 1500,
     description: "Only the foggiest!"
+    }
   });
 });
 


### PR DESCRIPTION
# Auth0 display tweaks and route integration
* This should be the final Auth0 branch addition that we will need for the project (keeping branch open just in case).
## Includes Matt's Saturday assistance
* Updates to Auth0 functionality/display
  * Much cleaner, now only displays login via google (no ability to signup with your own information).
  * On authentication user is redirected to their /dashboard automatically (still just contains the basics from google/Auth0).
* Route definitions and included params on PlantDetail page using 'this.props.match.params.id'.
  * These params are going to be used to bring up the specific user's plant detail.
