### PR TITLE
Plants.json started

### DIFF
--- a/client/src/pages/Survey/Plants.json
+++ b/client/src/pages/Survey/Plants.json
@@ -1,0 +1,44 @@
+[
+    {
+        "plantId": "1",
+        "plantCare": {
+            "hardinessZone": "9-10",
+            "soil": "Sandy",
+            "sun": "Full sun, Part sun",
+            "water": "Once every 3 weeks"
+        },
+        "plantName": "Aloe Vera",
+        "plantPic": "https://www.almanac.com/sites/default/files/styles/primary_image_in_article/public/image_nodes/aloe-vera-white-pot_sunwand24-ss_edit.jpg?itok=Y7HnaYk3",
+        "plantType": "House Plant",
+        "plantSci": "Aloe Vera",
+        "plantScore": "12345"
+    },
+    {
+        "plantId": "2",
+        "plantCare": {
+            "hardinessZone": "8-10",
+            "soil": "Loamy",
+            "sun": "Full sun, Part sun, Shade",
+            "water": "Once every 4 weeks"
+        },
+        "plantName": "Snake Plant",
+        "plantPic": "https://www.almanac.com/sites/default/files/styles/primary_image_in_article/public/image_nodes/shutterstock_679786570.jpg?itok=X2jXqX-x",
+        "plantType": "House Plant",
+        "plantSci": "Sansevieria trifasciata",
+        "plantScore": "12345"
+    },
+    {
+        "plantId": "3",
+        "plantCare": {
+            "hardinessZone": "10-11",
+            "soil": "Sandy",
+            "sun": "Full sun",
+            "water": "Once every 2.5 weeks"
+        },
+        "plantName": "Geranium",
+        "plantPic": "https://www.almanac.com/sites/default/files/styles/primary_image_in_article/public/image_nodes/geranium-2422730_1920.jpg?itok=cyx72G4f",
+        "plantType": "Patio Plant",
+        "plantSci": "Pelargonium",
+        "plantScore": "12345"
+    },
+]


### PR DESCRIPTION
### Plants.json lives in `/pages/Survey`

3 plants to get started on the Plants.json, keys are organized alphabetically with `plantId` ignoring that convention.

  * ### Some insight into the more abstract keys:
    * `hardinessZone` = [read more here](https://en.wikipedia.org/wiki/Hardiness_zone#/media/File:USDAHardiness_2012-2015_Scale.jpg) but essentially these numbers represent extreme minimum temperatures on an increasing scale where the higher the number the higher the minimum temperature; therefor a plant with a high `hardinessZone` value is actually less likely to survive in extreme low temperatures.  We could make a simple presentation page for beginner knowledge, including this very topic.
    * `plantScore` = survey answer values that add up to a "Best Match"
  * ### We should also do the research and add keys for:
    * `fertilizerTime`
    * `fertilizerType`
    * `soilAerate` (this is especially important for potted indoor plants due to the absence of worms performing this natural process)