### PR TITLE
Adding logout to deconstructor

### DIFF
--- a/client/src/components/Login/Login.component.js
+++ b/client/src/components/Login/Login.component.js
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 import { Redirect } from "react-router-dom";
 
 export const Login = (props) => {
-  const { isAuthenticated, loginWithRedirect } = useAuth0();
+  const { isAuthenticated, loginWithRedirect, logout } = useAuth0();
 
   return (
     <div className="text-center">


### PR DESCRIPTION
Somehow during the PR and merge of the `LandingPage` branch, the `logout` key associated with `useAuth0()` was omitted.
I added it back into the deconstructor and the changes are working as intended.