### PR TITLE
Redirect bug fix

### DIFF
--- a/client/src/components/Login/Login.component.js
+++ b/client/src/components/Login/Login.component.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { Button } from 'reactstrap';
 import { useAuth0 } from "../../react-auth0-spa";
-import { Link } from "react-router-dom";
-import { Redirect } from "react-router-dom";
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import "./styles.css";
 
@@ -20,10 +18,6 @@ export const Login = (props) => {
           Log in
         </Button>
       )}
-      
-      {isAuthenticated &&
-      (<Redirect to="/dashboard" />)
-      }
       {isAuthenticated && 
       <span className="text-center">
             <button onClick={() => logout()}> {<ExitToAppIcon />} </button>

--- a/client/src/pages/Landing/Landing.component.js
+++ b/client/src/pages/Landing/Landing.component.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import { Login } from '../../components/Login';
-
+import { useAuth0 } from "../../react-auth0-spa";
+import { Redirect } from "react-router-dom";
 import { Container, Row, Col } from 'reactstrap';
 
 export const Landing = (props) => {
+    const { isAuthenticated } = useAuth0();
     return (
-
+    <div>
+        {isAuthenticated &&
+            (<Redirect to="/dashboard" />)
+        }
         <Container id="landing-page-body" style={{ backgroundImage: `url(../banner5.jpg)`, backgroundSize: 'cover' }}>
 
             {/* WELCOME TEXT ROW  --------------  */}
@@ -24,6 +29,8 @@ export const Landing = (props) => {
             </Row>
 
         </Container>
+        
+    </div>
     )
 }
 


### PR DESCRIPTION
## Bug fix
I moved the `isauthenticated && redirect` check directly into the `Landing` class.
Originally it lived inside the `Login` component, so anywhere that component rendered it would check authentication status and redirect to the dashboard, now it just uses `isauthenticated` to display the `ExitToAppIcon`.
Now you'll only ever be redirected to the dashboard if you try to hit the root while being logged in.

### Some imports removed
I removed unnecessary imports of auth0 and react-router from the classes that no longer use them due to this fix.