### PR TITLE
Watering Schedule Logic (next step)

### DIFF
--- a/client/src/components/WateringSchedule/index.js
+++ b/client/src/components/WateringSchedule/index.js
@@ -1,22 +1,48 @@
 import React from "react";
-import Moment from 'react-moment';
+var moment = require('moment');
  
 
 export default class WateringSchedule extends React.Component {
 
-    // retrieve "days" for watering from MongoDb 
-    // ---- 'n' variable goes here ---- 
+    constructor(props){
+        super(props);
+    }
+    
+    componentDidMount(){
+        this.waterSchedule(); 
+    };
+    
+
+    waterSchedule = () => {
+        const date = new Date(); 
+
+        // date the plant was added (assuming that is the day the plant is being watered)
+         var plantAddedDate = date; // THIS NEEDS TO BE REPLACED WITH ACTUAL PLANT ADDED DATE
+        // how often the plant needs to be watered 
+         var wateringFreq = 7; // THIS NEEDS TO BE REPLACED WITH ACTAL WATER FREQ DATA FROM DB
+
+         // find next watering date by adding plant-added-date with watering frequency 
+         // ex: Plant added Oct 15 || Water-Freq is 7 days || Oct 15th + 7 days = October 22nd 
+         var nextWateringDate = moment(plantAddedDate).add(wateringFreq, 'days');
+            //console.log(nextWateringDate);
+         
+        // nextWateringDate - todaysDate = howmanydays?
+        var date1 = new Date();
+        var date2 = moment(nextWateringDate);
+        var diffInDays = date2.diff(date1, 'days');
+            console.log('diff: ' + diffInDays);
+            return diffInDays;
+    }
+
+
 
     render() {
-        // retrieve todays date
-        const date = new Date(); //Current Date
  
         return (
             <div>
-                {/* Add 'n' variable to todays date to get next watering date  */}
-                <h5> Water again on: </h5>
-                <Moment format="MM/DD" add={{ days: 1 }}>{date}</Moment>
+                <h5> Water again in {this.waterSchedule()} days </h5>
             </div>
         );
     }
+    
 }


### PR DESCRIPTION
In this watering schedule logic I did the following: 

- Took 'plant-added-date' as presumed date of watering and added the watering frequency to figure out the next watering date 
- Then added math to take todays date and the next watering date to figure out in how many days will the user be watering the plant next - and display it  

^ This is also still super MVP. 


**What is left to do:** 

- query the actual plant-added date from MongoDB
- query the actual watering frequency from MongoDB
- Need to add some sort of check mark or indication from the user that they watered the plant
- need to add a form to collect 'last watered' data from user when they are adding their own plant 
- need to figure out how to allow user to set their own 'last watered' date to a plant they added from the survey results - want to keep in mind user experience 