### PR TITLE
CSS Header Text Fixes

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -35,6 +35,20 @@ p {
   color: #3B9732;
 }
 
+#header-text {
+  padding-top: 20px;
+  padding-bottom: 10px;
+  background-color: #89AD39;
+  box-shadow: 5px 3px 18px #888888;
+  border-width: 5px;
+  margin-bottom: 20px;
+
+    top: 0;
+    /* position: fixed; */
+    /* width: 100%; */
+    z-index: 100;
+}
+
 /* -------- NAVIGATION BAR  ------------------------------- */
 
 #navbar-row {
@@ -93,21 +107,6 @@ p {
   max-height: 120px;
 }
 
-#dashboard-text {
-  padding-top: 20px;
-  padding-bottom: 10px;
-  background-color: #89AD39;
-  box-shadow: 5px 3px 18px #888888;
-  border-width: 5px;
-  margin-bottom: 20px;
-
-    top: 0;
-    position: fixed;
-    width: 100%;
-    z-index: 100;
-
-}
-
 #plant-info {
   line-height: 1em;
 }
@@ -122,5 +121,18 @@ p {
 
 #results-body {
   margin-bottom: 20%;
-  margin-top:25%;
+  /* margin-top:25%; */
+}
+
+
+/* ----------------------------------------------------------- */
+/* RESPONSIVNESS CSS ------------------------------------------- */
+
+@media screen and (min-width: 575px) {
+  #header-text{
+    display: block;
+    margin-right: auto;
+    margin-left: auto;
+    max-width: 800px;
+  }
 }

--- a/client/src/pages/AddPlant/AddPlant.component.js
+++ b/client/src/pages/AddPlant/AddPlant.component.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Input, TextArea, FormBtn } from "../../components/AddPlantForm";
 import BottomNav from "../../components/BottomNavigation"
+import { Container, Row, Col } from 'reactstrap';
 import "./AddPlant.css";
 
 
@@ -59,9 +60,14 @@ class AddPlant extends Component {
   render() {
     return (
       <div className="addPlantContainer">
-        <div className="top">
-        {/* should we have a header component, so we can have a header that's stylized across pages and only the text inside changes? */}
-        <h1>ADD YOUR PLANT</h1>
+
+      <Container id="container-body">
+        {/* 'YOUR PLANTS' - ROW  --------------  */}
+        <Row id="header-text">
+          <Col sm="12" md={{ size: 8, offset: 2 }}>
+            <h3> Add Your Plant </h3> 
+          </Col>
+        </Row>
 
         <form>
           <div className="imageContainer">
@@ -133,13 +139,14 @@ class AddPlant extends Component {
           >
             Submit
           </FormBtn>
-        </form>
-        </div>
 
-        <div className="bottom">
-        <BottomNav />
-        </div>
-      </div>
+        </form>
+
+      </Container>
+
+      <BottomNav />
+
+    </div>
 
     );
   }

--- a/client/src/pages/AddPlant/AddPlant.css
+++ b/client/src/pages/AddPlant/AddPlant.css
@@ -12,3 +12,8 @@
 	/* margin-left: 20px; */
 	width: 100%;
 }
+
+body {
+	margin-bottom: 20%;
+	background-color: black;
+}

--- a/client/src/pages/Dashboard/index.js
+++ b/client/src/pages/Dashboard/index.js
@@ -34,12 +34,12 @@ class Dashboard extends React.Component {
         return (
             <div>
             <User />
-            <Container id="dashboard-body">
+            <Container id="container-body">
 
-                {/* USER'S NAME - ROW  --------------  */}
-                <Row id="dashboard-text">
+                {/* 'YOUR PLANTS' - ROW  --------------  */}
+                <Row id="header-text">
                     <Col sm="12" md={{ size: 8, offset: 2 }}>
-                        <h3> [Name]'s Plants </h3> 
+                        <h3> Your Plants </h3> 
                     </Col>
                 </Row>
 

--- a/client/src/pages/PlantDetail/PlantDetail.component.js
+++ b/client/src/pages/PlantDetail/PlantDetail.component.js
@@ -47,7 +47,7 @@ class PlantDetail extends Component {
                 <Container id="plantid-body">
 
                     {/* PLANT NAME - ROW  --------------  */}
-                    <Row id="dashboard-text">
+                    <Row id="header-text">
                         <Col sm="12" md={{ size: 8, offset: 2 }}>
                             <h3>{this.state.userPlant.plantName}</h3>
                         </Col>

--- a/client/src/pages/Results/index.js
+++ b/client/src/pages/Results/index.js
@@ -128,7 +128,8 @@ class Results extends Component {
             <div>
                 <Container id="results-body">
 
-                    <Row id="dashboard-text">
+                    {/* 'YOUR RESULTS' - ROW  --------------  */}
+                    <Row id="header-text">
                         <Col sm="12" md={{ size: 8, offset: 2 }}>
                             <h3>Your Results</h3>
                         </Col>

--- a/client/src/pages/Survey/Survey.component.js
+++ b/client/src/pages/Survey/Survey.component.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Questions from "./Questions.json";
 import QACards from '../../components/QACards';
+import { Container, Row, Col } from 'reactstrap';
 import Button from '../../components/Button';
 import BottomNav from "../../components/BottomNavigation"
 
@@ -66,7 +67,15 @@ export class Survey extends Component {
                             render() {
         return (
             <div>
-                <h1>Survey page</h1>
+                <Container id="container-body">
+
+                {/* 'SURVEY PAGE' - ROW  --------------  */}
+                <Row id="header-text">
+                    <Col sm="12" md={{ size: 8, offset: 2 }}>
+                        <h3> Survey Page </h3> 
+                    </Col>
+                </Row>
+
                 {Questions.map(question =>
                 <QACards
                 key={question.number}
@@ -82,7 +91,11 @@ export class Survey extends Component {
                 />
                 )}
                 <Button onClick={this.handleSubmit} >Submit</Button>
+
+                </Container>
+
                 <BottomNav />
+
             </div>
         );
     }


### PR DESCRIPTION
Every single page (dashboard, survey, survey results, add plant, plant detail) now has fully responsive header-text display and is evenly centered in desktop or ipad mode.

The following was changed:
- Every page component now has react-strap grid imported
- Every page component now has a row with id "text-header" - where the CSS is being manipulated globally in index.css
- Added CSS for when device screen size min-width is 575px, then max width will expand to 800px and will grow no wider to maintain a 'mobile' feel but displays well on desktop with even margins and centered header. 

This PR does NOT fix: 
- the nav bar
- vertical height of some pages (getting cut off at bottom)

