### PR TITLE
Add Plant Page Input Form Changes

### DIFF
--- a/client/src/pages/AddPlant/AddPlant.component.js
+++ b/client/src/pages/AddPlant/AddPlant.component.js
@@ -69,6 +69,8 @@ class AddPlant extends Component {
           </Col>
         </Row>
 
+        <h6>* denotes required field</h6>
+
         <form>
           <div className="imageContainer">
             {/* <div>
@@ -80,7 +82,7 @@ class AddPlant extends Component {
                 value={this.state.url}
                 onChange={this.handleInputChange}
                 name="url"
-                placeholder="Insert Photo URL (optional)"
+                placeholder="Insert Photo URL"
               />
             </div>
           </div>
@@ -89,48 +91,58 @@ class AddPlant extends Component {
             value={this.state.name}
             onChange={this.handleInputChange}
             name="name"
-            placeholder="Plant Name (required)"
+            placeholder="Plant Name*"
           />
 
           <Input
             value={this.state.nickname}
             onChange={this.handleInputChange}
             name="nickname"
-            placeholder="Plant Nickname (optional)"
+            placeholder="Plant Nickname"
           />
 
           <Input
             value={this.state.sciname}
             onChange={this.handleInputChange}
             name="sciname"
-            placeholder="Scientific Name (optional)"
+            placeholder="Scientific Name"
           />
 
           <Input
             value={this.state.soilcare}
             onChange={this.handleInputChange}
             name="soilcare"
-            placeholder="Plant Soil Care (optional)"
+            placeholder="Soil Type"
           />
 
           <Input
             value={this.state.suncare}
             onChange={this.handleInputChange}
             name="suncare"
-            placeholder="Plant Sun Care (required)"
+            placeholder="Sun*"
           />
-          <TextArea
+          <Input
             value={this.state.watercare}
             onChange={this.handleInputChange}
             name="watercare"
-            placeholder="Plant Watering Care (required)"
+            placeholder="Watering Frequency (in days)*"
+          />
+
+          <Input
+            // NOTE: this 'value' needs to be confirmed - Added in this new input form for front-end purposes
+            // and watering schedule purposes 
+
+            // value={this.state.lastwatered}
+            onChange={this.handleInputChange}
+            name="watercare"
+            placeholder="Last Watered (in days)"
           />
 
           <Input
             value={this.state.toxicity}
             onChange={this.handleInputChange}
             name="toxicity"
-            placeholder="Plant Toxicity(optional)"
+            placeholder="Is the plant toxic to pets? (Yes or No)"
           />
 
           <FormBtn


### PR DESCRIPTION
Add Plant page edited to:
- have less placeholder text in input forms 
- anything that is required now has an asterisk (*) instead of (required) in the placeholder text, and a line at the top of the form says " * denotes required field" - this just makes the form look cleaner overall
- changed the 'water care' text form into an input form instead because it only requires an integer from the user

MOST IMPORTANT: 
- added a new input form that accepts a 'last watered' (in days) integer - I added this because I will need this number to make the watering schedule more accurate for the user. 
Because each input was set up with a specific value (   value={this.state.watercare}    ) I have commented out the value for "last watered" until someone can guide me or add a spot in the database to collect the information for  "last watered"