### PR TITLE
Matching on results updated

### DIFF
--- a/client/src/pages/Results/index.js
+++ b/client/src/pages/Results/index.js
@@ -38,7 +38,7 @@ class Results extends Component {
             nonToxic = Plants.filter(plant => plant.nonToxic === true);
             let match = 0;
             for (let i = 0; i < nonToxic.length; i++) {
-                for (let j = 0; j < 4; j++)
+                for (let j = 0; j < 5; j++)
                 if (nonToxic[i].plantScore[j] === this.state.matchScore[j]){
                     match++;
                 }


### PR DESCRIPTION
### Minor modification.
Now looping through entire `nonToxic` array in case the `nonToxic` question is the only match.
Users could possibly wind up with zero plants if this wasn't the case.  At the very least wind up with just one or two plants.