### PR TITLE
Plant Card Divider Line - Length Fix

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -188,6 +188,15 @@ button {
   }
 }
 
+@media screen and (min-width: 575px) {
+  #plant-row{
+    display: block;
+    margin-right: auto;
+    margin-left: auto;
+    max-width: 800px;
+  }
+}
+
 /* @media screen and (min-width: 575px) {
   #container-body{
     display: block;


### PR DESCRIPTION
Divider line that separates the plant cards is now max 800px on larger devices so it doesn't stretch longer than the top header.

Please test on your PC, MAC and HEROKU and in MOBILE and DESKTOP to ensure that it is looking good across all platforms. Please let me know asap if it's still looking wonky and I have a backup solution. Thanks!