### PR TITLE
Organized feed into a card col layout from reactstrap

### DIFF
--- a/client/src/pages/Feed/Feed.component.js
+++ b/client/src/pages/Feed/Feed.component.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import firebase from "firebase";
 import FileUploader from "react-firebase-file-uploader";
 import BottomNav from '../../components/BottomNavigation';
-import { Container, Row, Col } from 'reactstrap';
+import { Container, Row, Col, CardColumns, Card, CardImg } from 'reactstrap';
 import API from "../../utils/API";
 // import {DropzoneDialog} from 'material-ui-dropzone'
 // import Button from '@material-ui/core/Button';
@@ -111,12 +111,16 @@ class Feed extends Component {
  
         <p>Progress: {this.state.uploadProgress}</p>
         </div>
-        <div>
-          {this.state.downloadURLs.map((downloadURL, i) => {
-            return <img key={i} src={downloadURL} />;
-          })}
-        </div>
 
+        <CardColumns>
+          {this.state.downloadURLs.map((downloadURL, i) => {
+            return (
+              <Card>
+                <CardImg top width="100%" id={i} src={downloadURL} alt="Plant Imnage" />
+              </Card>
+            );
+          })}
+        </CardColumns>
 
         </Container>
         


### PR DESCRIPTION
I set up some card columns for our feed so that the images are somewhat more organized/aesthetic. It looks like reactstrap handles the autosizing of the images so we don't have to worry about it.

<img width="1680" alt="Screen Shot 2019-12-01 at 4 51 51 PM" src="https://user-images.githubusercontent.com/50184318/69923587-eb914600-145a-11ea-901b-357ef726ae11.png">

For some reason it's not scrolling properly, I think it might just be a styling issue with padding/margins so I can try to look at it and see what I can do. @Zuzanav if you have any insight that would be greatly appreciated so that I don't break any system-wide theming you may have going on.

My next step is to try to add an onClick to each image that opens them to full size in a modal. Eventually I envision this becoming an instagram-like feature where clicking on the image opens the image in a larger size and allows for commenting (but probably not by our deadline). 