### PR TITLE
Results Page - CSS Fixes for Desktop + Mobile too

### DIFF
--- a/client/src/components/InfoCard/index.js
+++ b/client/src/components/InfoCard/index.js
@@ -13,7 +13,7 @@ import { Button, Card, CardImg, CardText, CardBody } from 'reactstrap';
                         {/* { props.days &&  <li>Water every {props.days} days.</li> } */}
                         { props.water && <li> {props.water}</li> }
                     </ul>
-                    <Button className="float-right" onClick={props.onClick}>{props.label}</Button>
+                    <button className="float-right" onClick={props.onClick}>{props.label}</button>
                 </CardBody>
             </Card>
         </div>

--- a/client/src/components/PlantDashCard/index.js
+++ b/client/src/components/PlantDashCard/index.js
@@ -15,6 +15,12 @@ const PlantDashCard = (props) => {
                   <Row>
                     <Col sm="12" md={{ size: 8, offset: 2 }} lg={{ size: 8, offset: 3 }}>
                       <h5 id="plant-dash-header-text" style={{fontWeight: "bold"}}>{props.plantName} </h5>
+                    </Col>
+                  </Row>
+                  
+                  {/* NICKNAME ROW  */}
+                  <Row>
+                    <Col sm="12" md={{ size: 8, offset: 2 }} lg={{ size: 8, offset: 3 }}>
                       { props.plantNickname && <h5> Nickname: {props.plantNickname}</h5> }
                     </Col>
                   </Row>

--- a/client/src/components/PlantDisplayCard/index.js
+++ b/client/src/components/PlantDisplayCard/index.js
@@ -12,16 +12,34 @@ const PlantDisplayCard = (props) => {
   return (
     <div>
       <Card className="border-0">
+
             <div>
-                <img onClick={props.onClick} src={props.plantPic} className="float-left mr-3 plant-img" alt="Plant Image" />  
+
+            {/* PLANT TITLE ROW  */}
+            <Row>
+              <Col sm="12" md={{ size: 8, offset: 0 }} lg={{ size: 8, offset: 0 }}>
                 <p style={{fontWeight: "bold"}} >{props.plantName} </p>
+              </Col>
+            </Row>
+
+            {/* IMAGE + SUMMARY ROW  */}
+            <Row>
+              {/* IMAGE COLUMN  */}
+              <Col sm="4" md={{ size: 2, offset: 0 }} lg={{ size: 3, offset: 0 }}>
+                <img onClick={props.onClick} src={props.plantPic} className="float-left mr-3 plant-img" alt="Plant Image" />
+              </Col>
+              {/* TEXT COLUMN  */}
+              <Col sm="6" md={{ size: 8, offset: 2 }} lg={{ size: 7, offset: 2 }}>
                 <p>{props.children}</p>
-                { props.plantNickname && <p> Nickname: {props.plantNickname}</p> }
-                <p>Sun: {props.sun}</p>
-                <p>Soil: {props.soil}</p>
-                <p>Water: {props.water}</p>
+                  { props.plantNickname && <p> Nickname: {props.plantNickname}</p> }
+                  <p>Sun: {props.sun}</p>
+                  <p>Soil: {props.soil}</p>
+                  <p>Water: {props.water}</p>
+              </Col>
+            </Row>
                   <Button className="float-right" onClick={props.onClick}>{props.label}</Button>
             </div>
+
       </Card>
     </div>
   );

--- a/client/src/components/PlantDisplayCard/index.js
+++ b/client/src/components/PlantDisplayCard/index.js
@@ -33,7 +33,7 @@ const PlantDisplayCard = (props) => {
                   <p>Water: {props.water}</p>
               </Col>
             </Row>
-                  <Button className="float-right" onClick={props.onClick}>{props.label}</Button>
+                  <button className="float-right" onClick={props.onClick}>{props.label}</button>
             </div>
 
       </Card>

--- a/client/src/components/PlantDisplayCard/index.js
+++ b/client/src/components/PlantDisplayCard/index.js
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  Card, CardImg, CardText, 
-  CardBody, Button
-} from 'reactstrap';
-import { Container, Row, Col } from 'reactstrap';
+import { Card, Button, Row, Col } from 'reactstrap';
 import "./styles.css";
 import { PinDropRounded } from '@material-ui/icons';
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -345,7 +345,7 @@ button {
 @media screen and (min-width: 800px) {
   .plant-img {
   max-width: 800px;
-  max-height: 200px;
+  max-height: 150px;
   margin-left: -15%;
   }
 }


### PR DESCRIPTION
Results Page in desktop was off-kilter. - Now works fine and its responsive to mobile as well with text falling underneath the plant image. 

In Desktop, the text appears on the right of the image. 

Title in all resolutions now appears on the top left of the plant image. 

NEW COMMIT(S) - 
- Fixes nickname display (hopefully) on the dashboard 
- Fixes button color 