### PR TITLE
Changed website meta info

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Houseplant discovery, caring, and sharing"
     />
     <link rel="apple-touch-icon" href="logo192.png" />
     <!--


### PR DESCRIPTION
I noticed that our website's meta tag was still set to the generic "Web site created using create-react-app" message so I changed it to something more descriptive. 